### PR TITLE
Improve signal dashboard asset sidebar styling

### DIFF
--- a/trading/templates/trading/signal_dashboard.html
+++ b/trading/templates/trading/signal_dashboard.html
@@ -1199,25 +1199,29 @@
     
     /* Assets Sidebar */
     .assets-sidebar {
-        width: 280px;
-        min-width: 280px;
-        background-color: var(--fiona-card-dark);
-        border: 1px solid var(--fiona-border);
-        border-radius: 12px;
+        width: 320px;
+        min-width: 320px;
+        background: radial-gradient(circle at 20% 20%, rgba(46, 120, 214, 0.18), transparent 35%),
+                    radial-gradient(circle at 80% 0%, rgba(26, 188, 156, 0.18), transparent 30%),
+                    var(--fiona-card-dark);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+        border-radius: 14px;
         display: flex;
         flex-direction: column;
         overflow: hidden;
         position: sticky;
         top: 1rem;
         max-height: calc(100vh - 130px);
+        box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+        backdrop-filter: blur(6px);
     }
-    
+
     .sidebar-header {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding: 0.75rem 1rem;
-        background-color: var(--fiona-card-header);
+        padding: 0.85rem 1.2rem;
+        background: linear-gradient(90deg, rgba(255, 255, 255, 0.05), transparent);
         border-bottom: 1px solid var(--fiona-border);
     }
     
@@ -1235,7 +1239,8 @@
     .sidebar-content {
         flex: 1;
         overflow-y: auto;
-        padding: 0.5rem;
+        padding: 0.75rem 0.9rem 1rem;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0));
     }
     
     .sidebar-loading {
@@ -1255,74 +1260,139 @@
     
     /* Asset Item Card */
     .asset-item {
-        background-color: rgba(0, 0, 0, 0.2);
-        border-radius: 8px;
-        padding: 0.75rem;
-        margin-bottom: 0.5rem;
-        border-left: 3px solid var(--fiona-border);
-        transition: all 0.2s ease;
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01));
+        border-radius: 12px;
+        padding: 0.9rem;
+        margin-bottom: 0.65rem;
+        border: 1px solid rgba(255, 255, 255, 0.05);
+        transition: all 0.22s ease;
+        box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+        position: relative;
+        overflow: hidden;
     }
-    
+
+    .asset-item::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(120deg, rgba(46, 120, 214, 0.12), rgba(255, 255, 255, 0));
+        opacity: 0;
+        transition: opacity 0.25s ease;
+    }
+
     .asset-item:hover {
-        background-color: rgba(0, 0, 0, 0.3);
-        transform: translateX(2px);
+        transform: translateY(-2px);
+        border-color: rgba(255, 255, 255, 0.12);
+        box-shadow: 0 14px 26px rgba(0, 0, 0, 0.32);
     }
-    
+
+    .asset-item:hover::before {
+        opacity: 1;
+    }
+
     .asset-item:last-child {
         margin-bottom: 0;
     }
     
     .asset-item.phase-tradeable {
-        border-left-color: var(--signal-long);
+        box-shadow: 0 0 0 1px rgba(40, 167, 69, 0.3), 0 10px 24px rgba(40, 167, 69, 0.08);
     }
-    
+
     .asset-item.phase-range-building {
-        border-left-color: var(--confidence-medium);
+        box-shadow: 0 0 0 1px rgba(255, 193, 7, 0.24), 0 10px 24px rgba(255, 193, 7, 0.06);
     }
-    
+
     .asset-item.phase-other {
-        border-left-color: var(--fiona-text-muted);
+        box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.05), 0 10px 20px rgba(0, 0, 0, 0.25);
     }
-    
+
     .asset-item.phase-not-tradeable {
-        border-left-color: var(--signal-short);
-        opacity: 0.7;
+        box-shadow: 0 0 0 1px rgba(220, 53, 69, 0.3), 0 12px 26px rgba(220, 53, 69, 0.08);
+        opacity: 0.85;
     }
     
     .asset-item-header {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        margin-bottom: 0.5rem;
+        margin-bottom: 0.6rem;
+        gap: 0.75rem;
     }
-    
+
+    .asset-identity {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+    }
+
+    .asset-title {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+    }
+
+    .asset-avatar {
+        width: 38px;
+        height: 38px;
+        border-radius: 10px;
+        background: linear-gradient(145deg, rgba(46, 120, 214, 0.35), rgba(46, 120, 214, 0.15));
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 700;
+        color: #dfe7ff;
+        letter-spacing: 0.5px;
+        text-transform: uppercase;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    }
+
     .asset-name {
-        font-weight: 600;
+        font-weight: 700;
         color: var(--fiona-text-light);
-        font-size: 0.9rem;
+        font-size: 0.95rem;
+        letter-spacing: 0.2px;
     }
-    
+
+    .asset-symbol {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.15rem 0.55rem;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.05);
+        color: var(--fiona-text-muted);
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        border: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
     .asset-price {
         font-family: 'Roboto Mono', monospace;
         font-weight: 700;
-        color: #17a2b8;
-        font-size: 0.9rem;
+        color: #36d7b7;
+        font-size: 1rem;
+        padding: 0.35rem 0.65rem;
+        border-radius: 10px;
+        background: rgba(54, 215, 183, 0.08);
+        border: 1px solid rgba(54, 215, 183, 0.18);
     }
     
     .asset-phase-info {
-        margin-bottom: 0.5rem;
+        margin-bottom: 0.6rem;
     }
     
     .asset-phase-badge {
         display: inline-flex;
         align-items: center;
         gap: 0.35rem;
-        padding: 0.2rem 0.5rem;
-        border-radius: 4px;
-        font-size: 0.7rem;
-        font-weight: 600;
+        padding: 0.3rem 0.65rem;
+        border-radius: 999px;
+        font-size: 0.72rem;
+        font-weight: 700;
         text-transform: uppercase;
-        letter-spacing: 0.5px;
+        letter-spacing: 0.6px;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
     }
     
     .asset-phase-badge.tradeable {
@@ -1352,9 +1422,9 @@
     .asset-range-info {
         display: grid;
         grid-template-columns: 1fr 1fr;
-        gap: 0.5rem;
-        padding-top: 0.5rem;
-        border-top: 1px solid rgba(255, 255, 255, 0.1);
+        gap: 0.6rem;
+        padding-top: 0.6rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
     }
     
     .range-item {
@@ -1363,16 +1433,17 @@
     }
     
     .range-label {
-        font-size: 0.65rem;
+        font-size: 0.68rem;
         color: var(--fiona-text-muted);
         text-transform: uppercase;
-        letter-spacing: 0.3px;
+        letter-spacing: 0.35px;
     }
     
     .range-value {
         font-family: 'Roboto Mono', monospace;
-        font-size: 0.8rem;
+        font-size: 0.88rem;
         color: var(--fiona-text-light);
+        letter-spacing: 0.2px;
     }
     
     .range-value.high {
@@ -2455,6 +2526,13 @@
             return num.toFixed(4);
         }
     }
+
+    function getAssetInitials(asset) {
+        const source = (asset.symbol || asset.name || '').trim();
+        if (!source) return '?';
+        const clean = source.replace(/[^a-zA-Z0-9]/g, '');
+        return escapeHtml(clean.substring(0, 3).toUpperCase());
+    }
     
     function renderAssetItem(asset) {
         const phaseClass = getPhaseClass(asset.phase_type);
@@ -2487,11 +2565,17 @@
         } else {
             phaseIcon = 'bi-dash-circle';
         }
-        
+
         return `
             <div class="asset-item phase-${phaseClass}">
                 <div class="asset-item-header">
-                    <span class="asset-name">${escapeHtml(asset.name)}</span>
+                    <div class="asset-identity">
+                        <div class="asset-avatar">${getAssetInitials(asset)}</div>
+                        <div class="asset-title">
+                            <span class="asset-name">${escapeHtml(asset.name)}</span>
+                            <span class="asset-symbol"><i class="bi bi-circle-fill" style="font-size: 0.55rem;"></i> ${escapeHtml(asset.symbol || 'N/A')}</span>
+                        </div>
+                    </div>
                     <span class="asset-price">${formatAssetPrice(asset.current_price)}</span>
                 </div>
                 <div class="asset-phase-info">


### PR DESCRIPTION
## Summary
- modernize the signal dashboard asset sidebar with gradients, shadows, and refined spacing
- add asset avatars, symbol badges, and richer price styling for better readability
- keep sidebar cards responsive while preserving phase and range details

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bfdda3d58832785464109e2dd2e9e)