### PR TITLE
Refine signal dashboard sidebar styling

### DIFF
--- a/trading/templates/trading/signal_dashboard.html
+++ b/trading/templates/trading/signal_dashboard.html
@@ -1196,16 +1196,15 @@
         gap: 1.5rem;
         min-height: calc(100vh - 120px);
     }
-    
+
     /* Assets Sidebar */
     .assets-sidebar {
-        width: 320px;
+        width: 340px;
         min-width: 320px;
-        background: radial-gradient(circle at 20% 20%, rgba(46, 120, 214, 0.18), transparent 35%),
-                    radial-gradient(circle at 80% 0%, rgba(26, 188, 156, 0.18), transparent 30%),
+        background: linear-gradient(180deg, rgba(46, 120, 214, 0.12), rgba(26, 188, 156, 0.04)),
                     var(--fiona-card-dark);
-        border: 1px solid rgba(255, 255, 255, 0.05);
-        border-radius: 14px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        border-radius: 16px;
         display: flex;
         flex-direction: column;
         overflow: hidden;
@@ -1220,293 +1219,227 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding: 0.85rem 1.2rem;
-        background: linear-gradient(90deg, rgba(255, 255, 255, 0.05), transparent);
+        padding: 0.9rem 1.25rem;
+        background: rgba(255, 255, 255, 0.03);
         border-bottom: 1px solid var(--fiona-border);
     }
-    
+
     .sidebar-header h5 {
         margin: 0;
         color: var(--fiona-text-light);
-        font-size: 0.875rem;
+        font-size: 0.95rem;
         text-transform: uppercase;
         letter-spacing: 0.5px;
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .sidebar-content {
         flex: 1;
         overflow-y: auto;
-        padding: 0.75rem 0.9rem 1rem;
-        background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0));
+        padding: 0.75rem 0.75rem 1rem;
     }
-    
+
+    .sidebar-list {
+        background: transparent;
+    }
+
     .sidebar-loading {
         display: flex;
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        padding: 2rem 1rem;
+        padding: 1.75rem 1rem;
         color: var(--fiona-text-muted);
         gap: 0.5rem;
+        font-size: 0.95rem;
     }
-    
+
     .sidebar-loading i {
-        font-size: 1.5rem;
+        font-size: 1.25rem;
         animation: spin 2s linear infinite;
     }
-    
-    /* Asset Item Card */
-    .asset-item {
-        background: linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01));
-        border-radius: 12px;
-        padding: 0.9rem;
-        margin-bottom: 0.65rem;
-        border: 1px solid rgba(255, 255, 255, 0.05);
-        transition: all 0.22s ease;
-        box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
-        position: relative;
-        overflow: hidden;
+
+    /* Asset List Items (Bootstrap inspired) */
+    .asset-list-item {
+        background: rgba(255, 255, 255, 0.02);
+        border-color: rgba(255, 255, 255, 0.05) !important;
+        padding: 0.9rem 1rem;
+        transition: all 0.2s ease;
+        color: var(--fiona-text-light);
     }
 
-    .asset-item::before {
-        content: '';
-        position: absolute;
-        inset: 0;
-        background: linear-gradient(120deg, rgba(46, 120, 214, 0.12), rgba(255, 255, 255, 0));
-        opacity: 0;
-        transition: opacity 0.25s ease;
+    .asset-list-item:hover {
+        background: rgba(46, 120, 214, 0.08);
+        border-color: rgba(46, 120, 214, 0.25) !important;
+        transform: translateX(2px);
+        box-shadow: inset 3px 0 0 rgba(46, 120, 214, 0.5);
     }
 
-    .asset-item:hover {
-        transform: translateY(-2px);
-        border-color: rgba(255, 255, 255, 0.12);
-        box-shadow: 0 14px 26px rgba(0, 0, 0, 0.32);
-    }
-
-    .asset-item:hover::before {
-        opacity: 1;
-    }
-
-    .asset-item:last-child {
-        margin-bottom: 0;
-    }
-    
-    .asset-item.phase-tradeable {
-        box-shadow: 0 0 0 1px rgba(40, 167, 69, 0.3), 0 10px 24px rgba(40, 167, 69, 0.08);
-    }
-
-    .asset-item.phase-range-building {
-        box-shadow: 0 0 0 1px rgba(255, 193, 7, 0.24), 0 10px 24px rgba(255, 193, 7, 0.06);
-    }
-
-    .asset-item.phase-other {
-        box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.05), 0 10px 20px rgba(0, 0, 0, 0.25);
-    }
-
-    .asset-item.phase-not-tradeable {
-        box-shadow: 0 0 0 1px rgba(220, 53, 69, 0.3), 0 12px 26px rgba(220, 53, 69, 0.08);
-        opacity: 0.85;
-    }
-    
-    .asset-item-header {
+    .asset-meta {
         display: flex;
-        justify-content: space-between;
         align-items: center;
-        margin-bottom: 0.6rem;
         gap: 0.75rem;
     }
 
-    .asset-identity {
+    .asset-avatar {
+        width: 42px;
+        height: 42px;
+        border-radius: 12px;
+        background: linear-gradient(135deg, rgba(58, 110, 165, 0.45), rgba(255, 255, 255, 0.08));
         display: flex;
         align-items: center;
-        gap: 0.6rem;
+        justify-content: center;
+        color: white;
+        font-weight: 700;
+        letter-spacing: 0.4px;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        text-transform: uppercase;
     }
 
     .asset-title {
         display: flex;
         flex-direction: column;
-        gap: 0.2rem;
-    }
-
-    .asset-avatar {
-        width: 38px;
-        height: 38px;
-        border-radius: 10px;
-        background: linear-gradient(145deg, rgba(46, 120, 214, 0.35), rgba(46, 120, 214, 0.15));
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        font-weight: 700;
-        color: #dfe7ff;
-        letter-spacing: 0.5px;
-        text-transform: uppercase;
-        border: 1px solid rgba(255, 255, 255, 0.06);
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+        gap: 0.15rem;
     }
 
     .asset-name {
         font-weight: 700;
         color: var(--fiona-text-light);
         font-size: 0.95rem;
-        letter-spacing: 0.2px;
     }
 
     .asset-symbol {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.25rem;
-        padding: 0.15rem 0.55rem;
-        border-radius: 999px;
-        background: rgba(255, 255, 255, 0.05);
         color: var(--fiona-text-muted);
-        font-size: 0.75rem;
+        font-size: 0.8rem;
+        letter-spacing: 0.2px;
         text-transform: uppercase;
-        border: 1px solid rgba(255, 255, 255, 0.05);
     }
 
-    .asset-price {
+    .price-badge {
         font-family: 'Roboto Mono', monospace;
-        font-weight: 700;
-        color: #36d7b7;
-        font-size: 1rem;
-        padding: 0.35rem 0.65rem;
-        border-radius: 10px;
-        background: rgba(54, 215, 183, 0.08);
-        border: 1px solid rgba(54, 215, 183, 0.18);
+        background: rgba(46, 120, 214, 0.1);
+        color: #8bc4ff;
+        border: 1px solid rgba(46, 120, 214, 0.35);
+        padding: 0.35rem 0.6rem;
     }
-    
-    .asset-phase-info {
-        margin-bottom: 0.6rem;
-    }
-    
-    .asset-phase-badge {
+
+    .phase-pill {
         display: inline-flex;
         align-items: center;
         gap: 0.35rem;
         padding: 0.3rem 0.65rem;
         border-radius: 999px;
-        font-size: 0.72rem;
+        font-size: 0.73rem;
         font-weight: 700;
+        letter-spacing: 0.4px;
         text-transform: uppercase;
-        letter-spacing: 0.6px;
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+        border: 1px solid transparent;
     }
-    
-    .asset-phase-badge.tradeable {
-        background-color: rgba(40, 167, 69, 0.2);
+
+    .phase-pill.tradeable {
+        background: rgba(40, 167, 69, 0.15);
         color: var(--signal-long);
-        border: 1px solid var(--signal-long);
+        border-color: rgba(40, 167, 69, 0.55);
     }
-    
-    .asset-phase-badge.range-building {
-        background-color: rgba(255, 193, 7, 0.2);
+
+    .phase-pill.range-building {
+        background: rgba(255, 193, 7, 0.15);
         color: var(--confidence-medium);
-        border: 1px solid var(--confidence-medium);
+        border-color: rgba(255, 193, 7, 0.6);
     }
-    
-    .asset-phase-badge.other {
-        background-color: rgba(108, 117, 125, 0.2);
-        color: var(--fiona-text-muted);
-        border: 1px solid var(--fiona-border);
-    }
-    
-    .asset-phase-badge.not-tradeable {
-        background-color: rgba(220, 53, 69, 0.2);
+
+    .phase-pill.not-tradeable {
+        background: rgba(220, 53, 69, 0.15);
         color: var(--signal-short);
-        border: 1px solid var(--signal-short);
+        border-color: rgba(220, 53, 69, 0.6);
     }
-    
-    .asset-range-info {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 0.6rem;
-        padding-top: 0.6rem;
-        border-top: 1px solid rgba(255, 255, 255, 0.08);
-    }
-    
-    .range-item {
-        display: flex;
-        flex-direction: column;
-    }
-    
-    .range-label {
-        font-size: 0.68rem;
+
+    .phase-pill.other {
+        background: rgba(108, 117, 125, 0.18);
         color: var(--fiona-text-muted);
-        text-transform: uppercase;
-        letter-spacing: 0.35px;
+        border-color: rgba(108, 117, 125, 0.5);
     }
-    
-    .range-value {
-        font-family: 'Roboto Mono', monospace;
-        font-size: 0.88rem;
+
+    .range-pills {
+        display: flex;
+        gap: 0.4rem;
+        flex-wrap: wrap;
+    }
+
+    .range-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.3rem 0.55rem;
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        font-size: 0.78rem;
         color: var(--fiona-text-light);
-        letter-spacing: 0.2px;
     }
-    
-    .range-value.high {
+
+    .range-pill .label {
+        color: var(--fiona-text-muted);
+        font-size: 0.72rem;
+    }
+
+    .range-pill.high {
+        border-color: rgba(40, 167, 69, 0.4);
         color: var(--signal-long);
     }
-    
-    .range-value.low {
+
+    .range-pill.low {
+        border-color: rgba(220, 53, 69, 0.4);
         color: var(--signal-short);
     }
-    
+
     /* Dashboard Main Content Area */
     .dashboard-main {
         flex: 1;
         min-width: 0;
     }
-    
+
     /* Sidebar Empty State */
     .sidebar-empty {
         display: flex;
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        padding: 2rem 1rem;
+        padding: 1.6rem 1rem;
         color: var(--fiona-text-muted);
         text-align: center;
+        gap: 0.4rem;
     }
-    
+
     .sidebar-empty i {
-        font-size: 2rem;
-        margin-bottom: 0.5rem;
-        opacity: 0.5;
+        font-size: 1.5rem;
+        opacity: 0.6;
     }
-    
+
     /* Responsive - Hide sidebar on mobile */
     @media (max-width: 992px) {
         .dashboard-layout {
             flex-direction: column;
         }
-        
+
         .assets-sidebar {
             width: 100%;
             min-width: 100%;
-            max-height: 300px;
+            max-height: 360px;
             position: relative;
             top: 0;
         }
-        
-        .sidebar-content {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-        }
-        
-        .asset-item {
-            flex: 1 1 calc(50% - 0.5rem);
-            min-width: 200px;
-            margin-bottom: 0;
+
+        .asset-list-item {
+            padding: 0.85rem 0.9rem;
         }
     }
-    
     @media (max-width: 576px) {
-        .asset-item {
-            flex: 1 1 100%;
+        .asset-list-item {
+            padding: 0.8rem 0.85rem;
         }
     }
 </style>
@@ -1553,12 +1486,16 @@
                         <i class="bi bi-arrow-clockwise"></i>
                     </button>
                 </div>
-                <div class="sidebar-content" id="sidebar-assets-list">
-                    <!-- Asset items will be dynamically loaded -->
-                    <div class="sidebar-loading">
-                        <i class="bi bi-hourglass-split"></i>
-                        <span>Lädt Assets...</span>
-                    </div>
+                <div class="sidebar-content">
+                    <ul class="list-group list-group-flush sidebar-list" id="sidebar-assets-list">
+                        <!-- Asset items will be dynamically loaded -->
+                        <li class="list-group-item bg-transparent border-0">
+                            <div class="sidebar-loading">
+                                <i class="bi bi-hourglass-split"></i>
+                                <span>Lädt Assets...</span>
+                            </div>
+                        </li>
+                    </ul>
                 </div>
             </aside>
             
@@ -2537,24 +2474,23 @@
     function renderAssetItem(asset) {
         const phaseClass = getPhaseClass(asset.phase_type);
         const phaseName = getPhaseDisplayName(asset.current_phase);
-        
+
         let rangeHtml = '';
         if (asset.previous_range && (asset.previous_range.high || asset.previous_range.low)) {
             rangeHtml = `
-                <div class="asset-range-info">
-                    <div class="range-item">
-                        <span class="range-label">High</span>
-                        <span class="range-value high">${formatAssetPrice(asset.previous_range.high)}</span>
-                    </div>
-                    <div class="range-item">
-                        <span class="range-label">Low</span>
-                        <span class="range-value low">${formatAssetPrice(asset.previous_range.low)}</span>
-                    </div>
+                <div class="range-pills ms-auto">
+                    <span class="range-pill high">
+                        <span class="label">High</span>
+                        ${formatAssetPrice(asset.previous_range.high)}
+                    </span>
+                    <span class="range-pill low">
+                        <span class="label">Low</span>
+                        ${formatAssetPrice(asset.previous_range.low)}
+                    </span>
                 </div>
             `;
         }
-        
-        let phaseBadgeClass = phaseClass;
+
         let phaseIcon = 'bi-circle-fill';
         if (phaseClass === 'tradeable') {
             phaseIcon = 'bi-lightning-charge-fill';
@@ -2567,25 +2503,25 @@
         }
 
         return `
-            <div class="asset-item phase-${phaseClass}">
-                <div class="asset-item-header">
-                    <div class="asset-identity">
+            <li class="list-group-item asset-list-item border-secondary-subtle">
+                <div class="d-flex justify-content-between align-items-center">
+                    <div class="asset-meta">
                         <div class="asset-avatar">${getAssetInitials(asset)}</div>
                         <div class="asset-title">
                             <span class="asset-name">${escapeHtml(asset.name)}</span>
-                            <span class="asset-symbol"><i class="bi bi-circle-fill" style="font-size: 0.55rem;"></i> ${escapeHtml(asset.symbol || 'N/A')}</span>
+                            <span class="asset-symbol">${escapeHtml(asset.symbol || 'N/A')}</span>
                         </div>
                     </div>
-                    <span class="asset-price">${formatAssetPrice(asset.current_price)}</span>
+                    <span class="badge rounded-pill price-badge">${formatAssetPrice(asset.current_price)}</span>
                 </div>
-                <div class="asset-phase-info">
-                    <span class="asset-phase-badge ${phaseBadgeClass}">
+                <div class="d-flex align-items-center gap-2 mt-2 flex-wrap">
+                    <span class="phase-pill ${phaseClass}">
                         <i class="bi ${phaseIcon}"></i>
                         ${escapeHtml(phaseName)}
                     </span>
+                    ${rangeHtml}
                 </div>
-                ${rangeHtml}
-            </div>
+            </li>
         `;
     }
     
@@ -2595,14 +2531,16 @@
         
         if (!assets || assets.length === 0) {
             container.innerHTML = `
-                <div class="sidebar-empty">
-                    <i class="bi bi-box-seam"></i>
-                    <span>Keine aktiven Assets</span>
-                </div>
+                <li class="list-group-item bg-transparent border-0">
+                    <div class="sidebar-empty">
+                        <i class="bi bi-box-seam"></i>
+                        <span>Keine aktiven Assets</span>
+                    </div>
+                </li>
             `;
             return;
         }
-        
+
         const html = assets.map(asset => renderAssetItem(asset)).join('');
         container.innerHTML = html;
     }
@@ -2626,10 +2564,12 @@
                 const container = document.getElementById('sidebar-assets-list');
                 if (container) {
                     container.innerHTML = `
-                        <div class="sidebar-empty">
-                            <i class="bi bi-exclamation-triangle"></i>
-                            <span>${escapeHtml(data.error || 'Fehler beim Laden')}</span>
-                        </div>
+                        <li class="list-group-item bg-transparent border-0">
+                            <div class="sidebar-empty">
+                                <i class="bi bi-exclamation-triangle"></i>
+                                <span>${escapeHtml(data.error || 'Fehler beim Laden')}</span>
+                            </div>
+                        </li>
                     `;
                 }
             }
@@ -2640,10 +2580,12 @@
             const container = document.getElementById('sidebar-assets-list');
             if (container) {
                 container.innerHTML = `
-                    <div class="sidebar-empty">
-                        <i class="bi bi-exclamation-triangle"></i>
-                        <span>Verbindungsfehler</span>
-                    </div>
+                    <li class="list-group-item bg-transparent border-0">
+                        <div class="sidebar-empty">
+                            <i class="bi bi-exclamation-triangle"></i>
+                            <span>Verbindungsfehler</span>
+                        </div>
+                    </li>
                 `;
             }
         });


### PR DESCRIPTION
## Summary
- restyle the signal dashboard asset sidebar with a Bootstrap-inspired card and list layout
- update asset rendering to show status pills, price badges, and range chips in a trading-style presentation
- adjust sidebar empty/loading states to use list items consistent with the new structure

## Testing
- python manage.py check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c00e912208327aaf1d4d219bbeca0)