### PR TITLE
Fix breakout chart reload when switching assets

### DIFF
--- a/trading/templates/trading/breakout_distance_chart.html
+++ b/trading/templates/trading/breakout_distance_chart.html
@@ -685,8 +685,12 @@
             return;
         }
 
-        const firstLoad = !chart || currentCandles.length === 0;
+        const firstLoad = !chart;
 
+        // Only replace the container with a loading spinner when the chart
+        // doesn't exist yet. For existing charts (e.g., switching assets or
+        // time windows), keep the chart DOM intact so Lightweight Charts keeps
+        // its canvas mounted and we can update the data in place.
         if (firstLoad) {
             showLoading();
         }


### PR DESCRIPTION
## Summary
- avoid replacing the chart DOM with the loading spinner when the chart already exists
- keep the Lightweight Charts canvas mounted while switching assets or time windows

## Testing
- python manage.py test trading.tests.BreakoutDistanceChartViewTest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c06b5083483279e1279792638fae6)