### PR TITLE
Refine dashboard sidebar layout and styling

### DIFF
--- a/trading/templates/trading/signal_dashboard.html
+++ b/trading/templates/trading/signal_dashboard.html
@@ -754,13 +754,19 @@
         background-color: rgba(255, 193, 7, 0.2);
         color: var(--confidence-medium);
     }
-    
+
     .price-position-badge.below {
         background-color: rgba(220, 53, 69, 0.2);
         color: var(--signal-short);
     }
-    
+
     .range-diagnostic-message {
+        margin-top: 0.75rem;
+        padding: 0.75rem;
+        background-color: rgba(0, 0, 0, 0.2);
+        border-radius: 8px;
+    }
+
     /* Diagnostic Criteria List - Accordion Style */
     .diagnostic-criteria {
         margin-top: 0.75rem;
@@ -1192,15 +1198,18 @@
      * Dashboard Layout with Sidebar
      * ========================================================= */
     .dashboard-layout {
-        display: flex;
+        display: grid;
+        grid-template-columns: minmax(320px, 340px) 1fr;
+        align-items: flex-start;
         gap: 1.5rem;
         min-height: calc(100vh - 120px);
+        width: 100%;
     }
 
     /* Assets Sidebar */
     .assets-sidebar {
-        width: 340px;
-        min-width: 320px;
+        width: 100%;
+        min-width: 0;
         background: linear-gradient(180deg, rgba(46, 120, 214, 0.12), rgba(26, 188, 156, 0.04)),
                     var(--fiona-card-dark);
         border: 1px solid rgba(255, 255, 255, 0.06);
@@ -1239,6 +1248,7 @@
         flex: 1;
         overflow-y: auto;
         padding: 0.75rem 0.75rem 1rem;
+        background: rgba(0, 0, 0, 0.18);
     }
 
     .sidebar-list {
@@ -1267,7 +1277,7 @@
 
     /* Asset List Items (Bootstrap inspired) */
     .asset-list-item {
-        background: rgba(255, 255, 255, 0.04);
+        background: rgba(0, 0, 0, 0.25);
         border-color: rgba(255, 255, 255, 0.06) !important;
         padding: 0.9rem 1rem;
         transition: all 0.2s ease;
@@ -1454,12 +1464,10 @@
     /* Responsive - Hide sidebar on mobile */
     @media (max-width: 992px) {
         .dashboard-layout {
-            flex-direction: column;
+            grid-template-columns: 1fr;
         }
 
         .assets-sidebar {
-            width: 100%;
-            min-width: 100%;
             max-height: 360px;
             position: relative;
             top: 0;


### PR DESCRIPTION
## Summary
- switch dashboard layout to a two-column grid to keep the asset sidebar fixed on the left
- darken the sidebar content and asset list items so prices stay readable on the dark theme
- adjust responsive rules to collapse the grid cleanly on smaller viewports

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c07ac9ed48327b5859a94691aecd2)