### PR TITLE
Improve realtime chart styling and streaming

### DIFF
--- a/core/static/core/js/breakout_distance_widget.js
+++ b/core/static/core/js/breakout_distance_widget.js
@@ -129,7 +129,7 @@
 
             try {
                 const [candlesRes, contextRes, rangesRes] = await Promise.all([
-                    fetch(`/fiona/api/breakout-distance-candles?asset_id=${this.assetId}&timeframe=${this.timeframe}&window=${this.hours}`),
+                    fetch(`/fiona/api/breakout-distance-candles?asset_id=${this.assetId}&timeframe=${this.timeframe}&window=${this.hours}&force_refresh=1`),
                     fetch(`/fiona/api/chart/${this.assetSymbol}/breakout-context`),
                     fetch(`/fiona/api/chart/${this.assetSymbol}/session-ranges?hours=${this.hours}`),
                 ]);

--- a/trading/templates/trading/breakout_distance_chart.html
+++ b/trading/templates/trading/breakout_distance_chart.html
@@ -699,7 +699,7 @@
             // Use the new Market Data Layer API for candles (broker-agnostic, Redis-backed)
             // Also load breakout context and session ranges for overlay data
             const [candlesRes, contextRes, rangesRes] = await Promise.all([
-                fetch(`/fiona/api/breakout-distance-candles?asset_id=${currentAssetId}&timeframe=${currentTimeframe}&window=${currentHours}`),
+                fetch(`/fiona/api/breakout-distance-candles?asset_id=${currentAssetId}&timeframe=${currentTimeframe}&window=${currentHours}&force_refresh=1`),
                 fetch(`/fiona/api/chart/${currentAsset}/breakout-context`),
                 fetch(`/fiona/api/chart/${currentAsset}/session-ranges?hours=${currentHours}`),
             ]);

--- a/trading/templates/trading/signal_dashboard.html
+++ b/trading/templates/trading/signal_dashboard.html
@@ -1626,11 +1626,21 @@
 
     .chart-modal-meta .meta-item span {
         font-size: 0.75rem;
-        color: var(--fiona-text-muted);
+        color: #cfd6e4;
+        letter-spacing: 0.01em;
     }
 
     .chart-modal-meta .meta-item strong {
         font-size: 1rem;
+        color: #f8fafc;
+    }
+
+    .chart-modal-meta .meta-item .phase-label {
+        color: #93c5fd;
+    }
+
+    .chart-modal-meta .meta-item .current-price {
+        color: #38bdf8;
     }
 
     .chart-modal-canvas {
@@ -1655,7 +1665,7 @@
     }
 
     .info-tile .label {
-        color: var(--fiona-text-muted);
+        color: #d0d7e2;
         font-size: 0.72rem;
         display: block;
         margin-bottom: 0.25rem;
@@ -1664,6 +1674,24 @@
     .info-tile .value {
         font-size: 0.95rem;
         font-weight: 700;
+        color: #f1f5f9;
+        letter-spacing: 0.01em;
+    }
+
+    .chart-modal-info-grid .value.price-high,
+    .chart-modal-info-grid .value.breakout-long,
+    .chart-modal-info-grid .value.distance-high {
+        color: var(--signal-long);
+    }
+
+    .chart-modal-info-grid .value.price-low,
+    .chart-modal-info-grid .value.breakout-short,
+    .chart-modal-info-grid .value.distance-low {
+        color: var(--signal-short);
+    }
+
+    .chart-modal-info-grid .value.emphasis {
+        color: #a5f3fc;
     }
 
     .chart-loading,
@@ -2046,7 +2074,7 @@
                 </div>
                 <div class="meta-item">
                     <span>Phase</span>
-                    <strong id="asset-chart-phase">--</strong>
+                    <strong id="asset-chart-phase" class="phase-label">--</strong>
                 </div>
                 <div class="meta-item">
                     <span>Fenster</span>
@@ -2054,42 +2082,42 @@
                 </div>
                 <div class="meta-item">
                     <span>Preis</span>
-                    <strong id="asset-chart-current-price">--</strong>
+                    <strong id="asset-chart-current-price" class="current-price">--</strong>
                 </div>
             </div>
             <div id="asset-chart-container" class="chart-modal-canvas"></div>
             <div class="chart-modal-info-grid">
                 <div class="info-tile">
                     <span class="label">Referenz-Range</span>
-                    <span class="value" id="asset-chart-reference">--</span>
+                    <span class="value emphasis" id="asset-chart-reference">--</span>
                 </div>
                 <div class="info-tile">
                     <span class="label">Range High</span>
-                    <span class="value" id="asset-chart-range-high">--</span>
+                    <span class="value price-high" id="asset-chart-range-high">--</span>
                 </div>
                 <div class="info-tile">
                     <span class="label">Range Low</span>
-                    <span class="value" id="asset-chart-range-low">--</span>
+                    <span class="value price-low" id="asset-chart-range-low">--</span>
                 </div>
                 <div class="info-tile">
                     <span class="label">Breakout Long</span>
-                    <span class="value" id="asset-chart-breakout-long">--</span>
+                    <span class="value breakout-long" id="asset-chart-breakout-long">--</span>
                 </div>
                 <div class="info-tile">
                     <span class="label">Breakout Short</span>
-                    <span class="value" id="asset-chart-breakout-short">--</span>
+                    <span class="value breakout-short" id="asset-chart-breakout-short">--</span>
                 </div>
                 <div class="info-tile">
                     <span class="label">Distance High</span>
-                    <span class="value" id="asset-chart-distance-high">--</span>
+                    <span class="value distance-high" id="asset-chart-distance-high">--</span>
                 </div>
                 <div class="info-tile">
                     <span class="label">Distance Low</span>
-                    <span class="value" id="asset-chart-distance-low">--</span>
+                    <span class="value distance-low" id="asset-chart-distance-low">--</span>
                 </div>
                 <div class="info-tile">
                     <span class="label">Status</span>
-                    <span class="value" id="asset-chart-range-status">--</span>
+                    <span class="value emphasis" id="asset-chart-range-status">--</span>
                 </div>
             </div>
         </div>

--- a/trading/views.py
+++ b/trading/views.py
@@ -2326,7 +2326,8 @@ def api_breakout_distance_candles(request):
         asset_id: Required - Asset ID to fetch candles for
         timeframe: Candle timeframe (default: '1m', options: 1m, 5m, 15m, 1h)
         window: Time window in hours (default: 6, options: 1, 3, 6, 8, 12, 24, 48, 72)
-    
+        force_refresh: Optional flag to force refresh from the realtime stream/broker
+
     Returns JSON with:
         - success: Whether the request was successful
         - asset: Asset symbol
@@ -2360,6 +2361,10 @@ def api_breakout_distance_candles(request):
         window_hours = float(request.GET.get('window', 6))
     except (ValueError, TypeError):
         window_hours = 6
+
+    # Optional flag to force a refresh from the realtime stream instead of cached data
+    force_refresh_param = request.GET.get('force_refresh', '').lower()
+    force_refresh = force_refresh_param in {'1', 'true', 'yes'}
     
     try:
         # Get the asset
@@ -2377,6 +2382,7 @@ def api_breakout_distance_candles(request):
             asset=asset,
             timeframe=timeframe,
             window_hours=window_hours,
+            force_refresh=force_refresh,
         )
         
         return JsonResponse({


### PR DESCRIPTION
## Summary
- force breakout distance chart requests to refresh from the realtime stream instead of cached data
- color-code realtime chart modal values for high/low/long/short distances and increase text contrast for readability
- keep breakout dashboard chart fetches aligned with the live refresh flag

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c126c189c83278d7e5260c0d54644)