### PR TITLE
Add breakout fakeout detection

### DIFF
--- a/core/services/strategy/__init__.py
+++ b/core/services/strategy/__init__.py
@@ -9,6 +9,7 @@ from .models import (
     SCHEMA_VERSION,
     SetupKind,
     SessionPhase,
+    BreakoutSignal,
     BreakoutContext,
     EiaContext,
     Candle,
@@ -53,6 +54,7 @@ __all__ = [
     # Data models
     'SetupKind',
     'SessionPhase',
+    'BreakoutSignal',
     'BreakoutContext',
     'EiaContext',
     'Candle',


### PR DESCRIPTION
## Summary
- add breakout signal enum covering failed long/short breakout cases and surface it in breakout context
- extend breakout evaluations to detect fakeouts, invert signals, and emit explicit failure logs
- propagate fakeout handling through diagnostic criteria and strategy results

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c64c5fb348327abfd8dc4f66645e0)