### PR TITLE
Fix dataclass field order for API DTOs

### DIFF
--- a/fiona/api/dtos.py
+++ b/fiona/api/dtos.py
@@ -162,9 +162,9 @@ class SignalSummaryDTO:
     createdAt: str  # ISO format
     direction: str
     referencePrice: float
-    breakoutType: Optional[str] = None
     ki: KiInfoDTO
     risk: RiskInfoDTO
+    breakoutType: Optional[str] = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
@@ -205,11 +205,11 @@ class SignalDetailDTO:
     setupKind: str
     phase: str
     createdAt: str
-    breakoutType: Optional[str] = None
     setup: dict  # Serialized SetupCandidate
     kiEvaluation: Optional[dict] = None  # Serialized KiEvaluationResult
     riskEvaluation: Optional[RiskEvaluationDTO] = None
     executionState: Optional[ExecutionStateDTO] = None
+    breakoutType: Optional[str] = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""


### PR DESCRIPTION
## Summary
- reorder dataclass fields in `SignalSummaryDTO` and `SignalDetailDTO` so non-default fields precede defaults
- resolve dataclass initialization error triggered during Django checks

## Testing
- python manage.py check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c6a31628483278eed2e6e551adaab)