### PR TITLE
Handle invalid range zone data in breakout chart

### DIFF
--- a/core/static/core/js/breakout_distance_widget.js
+++ b/core/static/core/js/breakout_distance_widget.js
@@ -435,16 +435,18 @@
 
             const zoneStart = Number(startTime);
             const zoneEnd = Number(endTime);
-            if (Number.isNaN(zoneStart) || Number.isNaN(zoneEnd)) {
+            const zoneHigh = Number(rangeData.high);
+
+            if (!Number.isFinite(zoneStart) || !Number.isFinite(zoneEnd) || !Number.isFinite(zoneHigh)) {
                 this.rangeZoneSeries.setData([]);
                 return;
             }
 
             const dataPoints = zoneStart === zoneEnd
-                ? [{ time: zoneStart, value: Number(rangeData.high) }]
+                ? [{ time: zoneStart, value: zoneHigh }]
                 : [
-                    { time: zoneStart, value: Number(rangeData.high) },
-                    { time: zoneEnd, value: Number(rangeData.high) },
+                    { time: zoneStart, value: zoneHigh },
+                    { time: zoneEnd, value: zoneHigh },
                 ];
 
             this.rangeZoneSeries.setData(dataPoints);


### PR DESCRIPTION
## Summary
- guard range zone rendering against non-finite range data to prevent null values
- reuse validated range high values when constructing zone series points for the breakout chart

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c74f20db88327b6d39250af996d56)