### PR TITLE
Handle invalid breakout reference zone data on breakout chart

### DIFF
--- a/core/static/core/js/breakout_distance_widget.js
+++ b/core/static/core/js/breakout_distance_widget.js
@@ -453,7 +453,21 @@
                     { time: zoneEnd, value: zoneHigh },
                 ];
 
-            this.rangeZoneSeries.setData(dataPoints);
+            const sanitizedPoints = dataPoints.filter(point =>
+                Number.isFinite(point.time) && Number.isFinite(point.value)
+            );
+
+            if (!sanitizedPoints.length) {
+                this.rangeZoneSeries.setData([]);
+                return;
+            }
+
+            try {
+                this.rangeZoneSeries.setData(sanitizedPoints);
+            } catch (error) {
+                console.warn('Failed to render reference zone', error, sanitizedPoints);
+                this.rangeZoneSeries.setData([]);
+            }
         }
 
         _drawBreakoutContext(context) {


### PR DESCRIPTION
## Summary
- add extra guards before rendering breakout reference shading to avoid null values
- log and skip invalid data points so the chart keeps loading candles instead of throwing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c76bcced08327aee9c252c6b51c1e)