### PR TITLE
Use manual breakout ranges when available

### DIFF
--- a/core/services/broker/ig_market_state_provider.py
+++ b/core/services/broker/ig_market_state_provider.py
@@ -956,12 +956,15 @@ class IGMarketStateProvider(BaseMarketStateProvider):
             ).order_by('-end_time').first()
             
             if latest_range:
+                # Prefer manually adjusted ranges when available
+                high = float(latest_range.effective_high)
+                low = float(latest_range.effective_low)
                 logger.info(
                     f"Range loaded from database: asset={asset.symbol}, phase={phase}, "
-                    f"high={float(latest_range.high):.4f}, low={float(latest_range.low):.4f}, "
+                    f"high={high:.4f}, low={low:.4f}, "
                     f"end_time={latest_range.end_time.isoformat()}"
                 )
-                return (float(latest_range.high), float(latest_range.low))
+                return (high, low)
             
             logger.debug(f"No valid range found in database for {asset.symbol} {phase}")
             return None


### PR DESCRIPTION
## Summary
- load breakout ranges from the database using manual overrides when set
- log effective high/low values returned to the strategy engine

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ca995f8d083279a2973aa2873fde2)