### PR TITLE
Use 1m candles for realtime chart data

### DIFF
--- a/trading/services/chart_service.py
+++ b/trading/services/chart_service.py
@@ -131,7 +131,7 @@ class BreakoutContextData:
 class ChartCandlesResponse:
     """Response for candles endpoint."""
     asset: str
-    timeframe: str = '5m'
+    timeframe: str = '1m'
     hours: int = 1
     candles: List[CandleData] = field(default_factory=list)
     error: Optional[str] = None
@@ -175,7 +175,7 @@ def get_asset_by_symbol(symbol: str) -> Optional[TradingAsset]:
 def get_candles_for_asset(
     asset: TradingAsset,
     hours: int = 1,
-    timeframe: str = '5m',
+    timeframe: str = '1m',
 ) -> ChartCandlesResponse:
     """
     Get candlestick data for an asset from the appropriate broker API.
@@ -187,7 +187,7 @@ def get_candles_for_asset(
     Args:
         asset: TradingAsset instance
         hours: Number of hours of history (1, 3, 6, 8, 12, 24)
-        timeframe: Candle timeframe ('5m', '15m', '1h', etc.)
+        timeframe: Candle timeframe ('1m', '5m', '15m', '1h', etc.)
     
     Returns:
         ChartCandlesResponse with candle data

--- a/trading/tests.py
+++ b/trading/tests.py
@@ -3783,23 +3783,23 @@ class ChartCandlesAPITest(TestCase):
     def test_get_candles_success(self):
         """Test successful candle retrieval with price snapshot data."""
         from .models import PriceSnapshot
-        
+
         # Create price snapshots for the last hour
         now = timezone.now()
-        for i in range(12):  # 12 snapshots = 12 * 5 = 60 minutes
+        for i in range(60):  # 60 snapshots = 60 * 1 = 60 minutes
             PriceSnapshot.objects.create(
                 asset=self.asset,
-                timestamp=now - timedelta(minutes=55 - i * 5),
+                timestamp=now - timedelta(minutes=59 - i),
                 price_mid=Decimal(f'75.{i:02d}'),
             )
-        
+
         response = self.client.get('/fiona/api/chart/OIL/candles?hours=1')
         self.assertEqual(response.status_code, 200)
         
         data = response.json()
         self.assertTrue(data['success'])
         self.assertEqual(data['asset'], 'OIL')
-        self.assertEqual(data['timeframe'], '5m')
+        self.assertEqual(data['timeframe'], '1m')
         self.assertEqual(data['hours'], 1)
         self.assertIn('candles', data)
         self.assertIn('candle_count', data)
@@ -4055,20 +4055,20 @@ class ChartServiceTest(TestCase):
         """Test getting candles for asset with price snapshot data."""
         from .services.chart_service import get_candles_for_asset
         from .models import PriceSnapshot
-        
+
         # Create price snapshots for the last hour
         now = timezone.now()
-        for i in range(12):  # 12 snapshots = 12 * 5 = 60 minutes
+        for i in range(60):  # 60 snapshots = 60 * 1 = 60 minutes
             PriceSnapshot.objects.create(
                 asset=self.asset,
-                timestamp=now - timedelta(minutes=55 - i * 5),
+                timestamp=now - timedelta(minutes=59 - i),
                 price_mid=Decimal(f'75.{i:02d}'),
             )
-        
-        result = get_candles_for_asset(self.asset, hours=1, timeframe='5m')
-        
+
+        result = get_candles_for_asset(self.asset, hours=1, timeframe='1m')
+
         self.assertEqual(result.asset, 'OIL')
-        self.assertEqual(result.timeframe, '5m')
+        self.assertEqual(result.timeframe, '1m')
         self.assertEqual(result.hours, 1)
         self.assertIsNone(result.error)
         # Should have candles from snapshot data
@@ -4077,9 +4077,9 @@ class ChartServiceTest(TestCase):
     def test_get_candles_for_asset_no_data(self):
         """Test getting candles when no data is available."""
         from .services.chart_service import get_candles_for_asset
-        
-        result = get_candles_for_asset(self.asset, hours=1, timeframe='5m')
-        
+
+        result = get_candles_for_asset(self.asset, hours=1, timeframe='1m')
+
         self.assertEqual(result.asset, 'OIL')
         # Should have error message when no data available
         self.assertIsNotNone(result.error)

--- a/trading/views.py
+++ b/trading/views.py
@@ -2099,13 +2099,13 @@ def api_breakout_distance_chart_by_id(request, asset_id):
 @login_required
 def api_chart_candles(request, asset_code):
     """
-    GET /api/chart/{asset}/candles - Return 5-minute candlestick data.
+    GET /api/chart/{asset}/candles - Return 1-minute candlestick data.
     
     Path parameters:
         asset_code: Asset symbol (e.g., 'OIL', 'NAS100')
     
     Query parameters:
-        tf: Timeframe (default: '5m', currently only 5m supported)
+        tf: Timeframe (default: '1m')
         hours: Time window (1, 3, 6, 8, 12, 24) - default: 1
     
     Returns JSON with:
@@ -2116,7 +2116,7 @@ def api_chart_candles(request, asset_code):
         - candles: Array of OHLC data with unix timestamps
     """
     # Get query parameters
-    timeframe = request.GET.get('tf', '5m')
+    timeframe = request.GET.get('tf', '1m')
     try:
         hours = int(request.GET.get('hours', 1))
     except (ValueError, TypeError):


### PR DESCRIPTION
## Summary
- switch chart candle defaults to 1m for realtime API endpoints
- update chart service tests to align with 1m candle snapshots

## Testing
- python manage.py test trading.tests.ChartCandlesAPITest trading.tests.ChartServiceTest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d31c816d88327955dd59081d36183)