### PR TITLE
Ensure IG recent candles use last closed bars

### DIFF
--- a/core/services/strategy/providers.py
+++ b/core/services/strategy/providers.py
@@ -35,7 +35,8 @@ class MarketStateProvider(Protocol):
         self,
         epic: str,
         timeframe: str,
-        limit: int
+        limit: int,
+        closed_only: bool = False,
     ) -> list[Candle]:
         """
         Get recent candles for a market.
@@ -44,7 +45,9 @@ class MarketStateProvider(Protocol):
             epic: Market identifier.
             timeframe: Candle timeframe (e.g., '1m', '5m', '1h').
             limit: Maximum number of candles to return.
-            
+            closed_only: If True, exclude the currently forming candle and
+                return only closed candles.
+
         Returns:
             List of Candle objects, most recent last.
         """
@@ -161,7 +164,8 @@ class BaseMarketStateProvider(ABC):
         self,
         epic: str,
         timeframe: str,
-        limit: int
+        limit: int,
+        closed_only: bool = False,
     ) -> list[Candle]:
         """Get recent candles for a market."""
         pass

--- a/core/services/strategy/strategy_engine.py
+++ b/core/services/strategy/strategy_engine.py
@@ -126,7 +126,7 @@ class StrategyEngine:
         phase = self.market_state.get_phase(ts)
         
         # Get current price data for comprehensive logging
-        candles = self.market_state.get_recent_candles(epic, '1m', 1)
+        candles = self.market_state.get_recent_candles(epic, '1m', 1, closed_only=True)
         current_price = candles[-1].close if candles else None
         
         # Get range data only for the relevant phase to avoid misleading log messages

--- a/core/tests_strategy.py
+++ b/core/tests_strategy.py
@@ -349,7 +349,8 @@ class DummyMarketStateProvider(BaseMarketStateProvider):
         self,
         epic: str,
         timeframe: str,
-        limit: int
+        limit: int,
+        closed_only: bool = False,
     ) -> list[Candle]:
         return self._candles[:limit]
 


### PR DESCRIPTION
## Summary
- trim IG historical candle responses to only the most recent requested candles
- add closed_only support so callers can drop the currently forming candle and align with charts
- use closed candles in the strategy engine and add coverage for trimming and closed-only behavior

## Testing
- python manage.py test core.tests_worker.IGMarketStateProviderTest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df7b889f48327a9415ed5fae8530d)