### PR TITLE
Improve strategy status trace for missing setups

### DIFF
--- a/core/tests_strategy.py
+++ b/core/tests_strategy.py
@@ -559,7 +559,9 @@ class StrategyEngineBreakoutTest(TestCase):
         self.assertEqual(len(candidates), 0)
         self.assertEqual(
             engine.last_status_message,
-            "US breakout evaluation: price below range; "
+            "Breakout rejected: SHORT validation failed - Bearish breakout required "
+            "but candle closed higher than it opened (open 138.5000 < close 138.8000) "
+            "[US diagnostics breakout evaluation]; US breakout evaluation: price below range; "
             "Phase US_CORE_TRADING is tradeable but no valid setups found",
         )
 
@@ -588,6 +590,8 @@ class StrategyEngineBreakoutTest(TestCase):
         self.assertEqual(len(candidates), 0)
         self.assertEqual(
             engine.last_status_message,
+            "Breakout rejected: SHORT validation failed - Candle body 0.3000 below minimum "
+            "0.4000 (50% of range) [US diagnostics breakout evaluation]; "
             "US breakout evaluation: price below range; "
             "Phase PRE_US_RANGE is tradeable but no valid setups found",
         )


### PR DESCRIPTION
## Summary
- collect status history during strategy evaluation and use it to build detailed no-setup messages
- log the full status trace for missing candidates to aid debugging
- align strategy engine tests with the richer status output

## Testing
- python -m pytest core/tests_strategy.py::StrategyEngineTest::test_us_core_breakout_reports_price_position core/tests_strategy.py::StrategyEngineTest::test_pre_us_breakout_uses_london_core_range *(fails: Django settings not configured in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e0488fb488327ac7029285515f170)