### PR TITLE
Add entry price alias to broker position

### DIFF
--- a/core/services/broker/models.py
+++ b/core/services/broker/models.py
@@ -213,6 +213,7 @@ class Position:
             'direction': self.direction.value if isinstance(self.direction, Enum) else self.direction,
             'size': float(self.size),
             'open_price': float(self.open_price),
+            'entry_price': float(self.entry_price),
             'current_price': float(self.current_price),
             'unrealized_pnl': float(self.unrealized_pnl),
             'currency': self.currency,
@@ -220,6 +221,15 @@ class Position:
             'take_profit': float(self.take_profit) if self.take_profit is not None else None,
             'created_at': self.created_at.isoformat() if self.created_at else None,
         }
+
+    @property
+    def entry_price(self) -> Decimal:
+        """Alias for backward compatibility with callers expecting ``entry_price``."""
+        return self.open_price
+
+    @entry_price.setter
+    def entry_price(self, value: Decimal) -> None:
+        self.open_price = Decimal(str(value))
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add an entry_price alias to the broker Position model for callers expecting that attribute
- include entry_price in Position serialization output

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934421aeffc8327bf8f817a13329109)