### PR TITLE
Improve candle updates with bid/ask fallbacks

### DIFF
--- a/core/services/broker/ig_market_state_provider.py
+++ b/core/services/broker/ig_market_state_provider.py
@@ -668,13 +668,27 @@ class IGMarketStateProvider(BaseMarketStateProvider):
             
             price = broker_service.get_symbol_price(symbol)
             now = datetime.now(timezone.utc)
-            
+
+            mid_price = float(price.mid_price)
+            ask_price = float(price.ask) if price.ask is not None else mid_price
+            bid_price = float(price.bid) if price.bid is not None else mid_price
+            high_price = (
+                float(price.high)
+                if price.high is not None
+                else max(ask_price, bid_price, mid_price)
+            )
+            low_price = (
+                float(price.low)
+                if price.low is not None
+                else min(ask_price, bid_price, mid_price)
+            )
+
             candle = Candle(
                 timestamp=now,
-                open=float(price.mid_price),
-                high=float(price.high) if price.high else float(price.mid_price),
-                low=float(price.low) if price.low else float(price.mid_price),
-                close=float(price.mid_price),
+                open=mid_price,
+                high=high_price,
+                low=low_price,
+                close=mid_price,
                 volume=None,
             )
             


### PR DESCRIPTION
## Summary
- use bid/ask-derived fallbacks for candle high and low when price feeds lack session extremes
- ensure generated candles maintain a meaningful spread for range building

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693448aa1cf48327af2b795e18d312e1)